### PR TITLE
Fix bug, between expression removes other expressions

### DIFF
--- a/src/SQLBuilder/Expression.php
+++ b/src/SQLBuilder/Expression.php
@@ -90,7 +90,7 @@ class Expression
         $expr = new BetweenExpression( $column, $from, $to );
         $expr->builder = $this->builder;
         $expr->driver = $this->driver;
-        $this->op = $expr;
+        $this->setOp($expr);
         return $this;
     }
 

--- a/tests/SQLBuilder/ExpressionTest.php
+++ b/tests/SQLBuilder/ExpressionTest.php
@@ -187,5 +187,12 @@ class ExpressionTest extends PHPUnit_Framework_TestCase
         is( "created_on BETWEEN 10 AND 20" , $expr->toSql() );
     }
 
-}
+    public function testBetweenWithOtherExpression()
+    {
+        $expr = $this->createExpr();
+        $expr->equal('foo', 1)
+             ->between('id', 10, 20);
+        is( "foo = 1 AND id BETWEEN 10 AND 20", $expr->toSql() );
+    }
 
+}


### PR DESCRIPTION
`$builder->table('member')->select('*')->where()->equal('foo', 1)->between('id', 10, 20)->build();`
gets:
`SELECT * FROM  member WHERE id BETWEEN 10 AND 20`

expected result is:
`SELECT * FROM  member WHERE foo = 1 AND id BETWEEN 10 AND 20`
