### PR TITLE
Fix syntax error in UUIDQuery

### DIFF
--- a/src/Universal/Query/UUIDQuery.php
+++ b/src/Universal/Query/UUIDQuery.php
@@ -31,7 +31,7 @@ class UUIDQuery implements ToSqlInterface
             return 'SELECT UUID_GENERATE_V4();';
         }
         if ($driver instanceof SQLiteDriver) {
-            return 'SELECT SUBSTR(u, 1, 8)||'-'||SUBSTR(u, 9, 4)||'-4'||SUBSTR(u, 13, 3)|| '-'||v||SUBSTR(u, 17, 3)||'-'||SUBSTR(u, 21, 12) as uuid from (select LOWER(HEX(RANDOMBLOB(16))) as u, SUBSTR('89ab', ABS(RANDOM()) % 4 + 1, 1) as v);';
+            return "SELECT SUBSTR(u, 1, 8)||'-'||SUBSTR(u, 9, 4)||'-4'||SUBSTR(u, 13, 3)|| '-'||v||SUBSTR(u, 17, 3)||'-'||SUBSTR(u, 21, 12) as uuid from (select LOWER(HEX(RANDOMBLOB(16))) as u, SUBSTR('89ab', ABS(RANDOM()) % 4 + 1, 1) as v);";
         }
         throw new UnsupportedDriverException($driver, $this);
     }


### PR DESCRIPTION
The current line results in a syntax error in all versions of PHP (https://3v4l.org/3uKtb) - quoting the entire string appears to fix the issue (https://3v4l.org/Gh3Pd).